### PR TITLE
Set collection property to be collection always

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function methodExtend (Base, Promise) {
 function overrideCallback (callback, resolver) {
   return function (model, response, options) {
     if (callback) callback.apply(model, arguments);
-    resolver({ model: model, response: response, options: options, collection: model });
+    resolver({ model: model, response: response, options: options, collection: model.collection || model });
   };
 }
 


### PR DESCRIPTION
It is possible to use `model.collection || model` expression to guarantee collection property to be collection always.
